### PR TITLE
Fixed logging correct socket

### DIFF
--- a/dhcppython/client.py
+++ b/dhcppython/client.py
@@ -323,7 +323,7 @@ class DHCPClient(object):
         else:
             sock.bind((host, port))
 
-        logging.info(f"Bound {socket}")
+        logging.info(f"Bound {sock}")
         return sock
 
     def get_writing_sockets(self) -> List[socket.socket]:


### PR DESCRIPTION
At least in my case it's more useful to log some created object instead of a built-in module, which should be available, isn't it?