### PR TITLE
Exclude END option during packet parsing

### DIFF
--- a/tests/test_packet.py
+++ b/tests/test_packet.py
@@ -50,6 +50,10 @@ class PacketTestCases(unittest.TestCase):
             ack_linux
         )
 
+    def test_parse_exclude_end_option(self):
+        parsed_packet = packet.DHCPPacket.from_bytes(discover_linux)
+        self.assertIsNone(parsed_packet.options.by_code(255))
+
 
 request_android: List[int] = [
     0x01, 0x01, 0x06, 0x00, 0xea, 0xbe,


### PR DESCRIPTION
Exclude END option(code==255) during packet parsing. As result options
list in produced packet will not include the END option and as result
.append() method will not append new options behind End option. So
adding new option will not lead to producing malfolmed packet.