### PR TITLE
Added DHCPRELEASE, DHCPINFORM and option 82 suboptions 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DHCP Python
 
-Version 0.1.4
+Version 0.1.4b
 
 A Python implementation of a DHCP client and the tools to manipulate DHCP packets. Includes:
 

--- a/dhcppython/client.py
+++ b/dhcppython/client.py
@@ -155,6 +155,26 @@ class DHCPClient(object):
     ):
         self.send(server, self.send_to_port, release_packet.asbytes, verbosity)
 
+    def get_release(
+        self,
+        mac_addr: Optional[str] = None,
+        server: str = "255.255.255.255",
+        relay: Optional[str] = None,
+        client: Optional[str] = None,
+        broadcast: bool = True,        
+        options_list: Optional[options.OptionList] = None,
+        verbose: int = 0,            
+    ):
+        release = packet.DHCPPacket.Release(
+            mac_addr,
+            use_broadcast=broadcast,
+            option_list=options_list,
+            relay=relay,
+            client=client,
+        )
+        self.send_release(server=server, release_packet=release, verbosity=verbose)
+
+
     def get_lease(
         self,
         mac_addr: Optional[str] = None,

--- a/dhcppython/client.py
+++ b/dhcppython/client.py
@@ -155,7 +155,12 @@ class DHCPClient(object):
     ):
         self.send(server, self.send_to_port, release_packet.asbytes, verbosity)
 
-    def get_release(
+    def send_inform(
+        self, server: str, inform_packet: packet.DHCPPacket, verbosity: int
+    ):
+        self.send(server, self.send_to_port, inform_packet.asbytes, verbosity)
+
+    def put_release(
         self,
         mac_addr: Optional[str] = None,
         server: str = "255.255.255.255",
@@ -174,6 +179,38 @@ class DHCPClient(object):
         )
         self.send_release(server=server, release_packet=release, verbosity=verbose)
 
+    def put_inform(
+        self,
+        mac_addr: Optional[str] = None,
+        broadcast: bool = True,
+        relay: Optional[str] = None,
+        client: Optional[str] = None,
+        server: str = "255.255.255.255",
+        ip_protocol: int = 4,
+        options_list: Optional[options.OptionList] = None,
+        verbose: int = 0,
+    ):
+        mac_addr = mac_addr or utils.random_mac()
+        logging.debug("Synthetizing inform packet")
+
+        # I
+        start = int(default_timer())
+        inform = packet.DHCPPacket.Inform(
+            mac_addr,
+            int(default_timer()-start),
+            0,
+            use_broadcast=broadcast,
+            option_list=options_list,
+            client_ip=client,
+            relay=relay,
+        )
+        tx_id = inform.xid
+        if verbose > 1:
+            print("INFORM Packet")
+            print(format_dhcp_packet(inform))
+        logging.debug(f"Constructed inform packet: {inform}")
+        logging.debug(f"Sending inform packet to {server} with {tx_id=}")
+        self.send_inform(server, inform, verbose)        
 
     def get_lease(
         self,

--- a/dhcppython/client.py
+++ b/dhcppython/client.py
@@ -10,7 +10,7 @@ from . import packet, options, utils
 from .exceptions import DHCPClientError
 
 
-COL_LEN = 80
+COL_LEN = 80-3
 
 Lease = collections.namedtuple(
     "Lease", ["discover", "offer", "request", "ack", "time", "server"]
@@ -149,6 +149,11 @@ class DHCPClient(object):
             if verbosity > 1:
                 print("Did not receive ack packet")
         return ack
+
+    def send_release(
+        self, server: str, release_packet: packet.DHCPPacket, verbosity: int
+    ):
+        self.send(server, self.send_to_port, release_packet.asbytes, verbosity)
 
     def get_lease(
         self,

--- a/dhcppython/options.py
+++ b/dhcppython/options.py
@@ -1784,11 +1784,47 @@ class RelayAgentInformation(StrOption):
     """
     Option 82
 
-    Relay Agent Information
+    Relay Agent Information is comprised of suboptions with basically same 
+    structure as a string option.
+
     """
 
     code = 82
     key = "relay_agent_info"
+
+    code82 = {
+        1: "circuit_id",
+        2: "remote_id",
+    }
+    key82 = {
+        "circuit_id": 1,
+        "remote_id": 2,
+    }
+
+    @property
+    def value(self) -> Dict[str, Dict[str, str]]:
+
+        if self._value is None:
+            self._value = {}
+            data = self.data
+            while data:
+                code, length = struct.unpack(">BB",data[:2])
+                data0 = data[2:2+length]
+                self._value[self.code82[code]] = data0.decode()
+                data = data[2+length:]
+        return self._value
+
+    @classmethod
+    def from_value(cls, value):
+        data = b""
+        for raisub in ["circuit_id","remote_id"]:
+            if raisub in value[cls.key]:    
+                subval = value[cls.key][raisub]
+                data0 = subval.encode()
+                data += struct.pack(">Bb", cls.key82[raisub], len(data0)) + \
+                        struct.pack(">" + "B" * len(data0), *data0)
+        return cls(cls.code, len(data), data)
+
 
 
 class UnknownOption(BinOption):

--- a/dhcppython/packet.py
+++ b/dhcppython/packet.py
@@ -479,3 +479,52 @@ class DHCPPacket(object):
             fname,
             option_list,
         )
+
+    @classmethod
+    def Inform(
+        cls,
+        mac_addr: str,
+        seconds: int = 0,
+        tx_id: int = 0,
+        use_broadcast: bool = True,
+        relay: Optional[str] = None,
+        client_ip: Optional[str] = None,
+        sname: bytes = b"",
+        fname: bytes = b"",
+        option_list: Optional[options.OptionList] = None,
+    ):
+        """
+        Convenient constructor for a DHCP inform packet.
+        """
+        if len(mac_addr.split(":")) != 6 or len(mac_addr) != 17:
+            raise DHCPValueError(
+                "MAC address must consist of 6 octets delimited by ':'"
+            )
+        option_list = option_list if option_list else options.OptionList()
+        option_list.insert(0, options.options.short_value_to_object(53, "DHCPINFORM"))
+        relay_ip = ipaddress.IPv4Address(relay or 0)
+        client_ip = ipaddress.IPv4Address(client_ip or 0)
+        return cls(
+            "BOOTREQUEST",
+            cls.htype_map[1],  # 10 mb ethernet
+            6,  # 6 byte hardware addr
+            0,  # clients should set this to 0
+            tx_id or random.getrandbits(32),
+            seconds,
+            0b1000_0000_0000_0000 if use_broadcast else 0,
+            # ciaddr - client address
+            #ipaddress.IPv4Address(0),
+            client_ip,
+            # yiaddr - "your address", address being proposed by server
+            #ipaddress.IPv4Address(0),
+            client_ip,
+            # siaddr - servr address
+            ipaddress.IPv4Address(0),
+            # giaddr - gateway address = relay address
+            relay_ip,
+            mac_addr,
+            sname,
+            fname,
+            option_list,
+        )
+    

--- a/dhcppython/packet.py
+++ b/dhcppython/packet.py
@@ -430,3 +430,46 @@ class DHCPPacket(object):
             fname,
             option_list,
         )
+
+
+    @classmethod
+    def Release(
+        cls,
+        mac_addr: str,
+        seconds: int,
+        tx_id: int,
+        yiaddr: Union[int, str],
+        use_broadcast: bool = True,
+        relay: Optional[str] = None,
+        sname: bytes = b"",
+        fname: bytes = b"",
+        option_list: Optional[options.OptionList] = None,
+    ):
+        """
+        Convenient constructor for a DHCP release packet.
+        """
+        if len(mac_addr.split(":")) != 6 or len(mac_addr) != 17:
+            raise DHCPValueError(
+                "MAC address must consist of 6 octets delimited by ':'"
+            )
+        option_list = option_list if option_list else options.OptionList()
+        option_list.insert(0, options.options.short_value_to_object(53, "DHCPRELEASE"))
+        relay_ip = ipaddress.IPv4Address(relay or 0)
+        return cls(
+            "BOOTREQUEST",
+            cls.htype_map[1],  # 10 mb ethernet
+            6,  # 6 byte hardware addr
+            0,  # clients should set this to 0
+            tx_id,
+            seconds,
+            0b1000_0000_0000_0000 if use_broadcast else 0,
+            ipaddress.IPv4Address(0),
+            # yiaddr - "your address", address being proposed by server
+            ipaddress.IPv4Address(yiaddr),
+            ipaddress.IPv4Address(0),
+            relay_ip,
+            mac_addr,
+            sname,
+            fname,
+            option_list,
+        )

--- a/dhcppython/packet.py
+++ b/dhcppython/packet.py
@@ -436,11 +436,11 @@ class DHCPPacket(object):
     def Release(
         cls,
         mac_addr: str,
-        seconds: int,
-        tx_id: int,
-        yiaddr: Union[int, str],
+        seconds: int = 0,
+        tx_id: int = 0,
         use_broadcast: bool = True,
         relay: Optional[str] = None,
+        client: Optional[str] = None,
         sname: bytes = b"",
         fname: bytes = b"",
         option_list: Optional[options.OptionList] = None,
@@ -455,18 +455,24 @@ class DHCPPacket(object):
         option_list = option_list if option_list else options.OptionList()
         option_list.insert(0, options.options.short_value_to_object(53, "DHCPRELEASE"))
         relay_ip = ipaddress.IPv4Address(relay or 0)
+        client_ip = ipaddress.IPv4Address(client or 0)
         return cls(
             "BOOTREQUEST",
             cls.htype_map[1],  # 10 mb ethernet
             6,  # 6 byte hardware addr
             0,  # clients should set this to 0
-            tx_id,
+            tx_id or random.getrandbits(32),
             seconds,
             0b1000_0000_0000_0000 if use_broadcast else 0,
-            ipaddress.IPv4Address(0),
+            # ciaddr - client address
+            #ipaddress.IPv4Address(0),
+            client_ip,
             # yiaddr - "your address", address being proposed by server
-            ipaddress.IPv4Address(yiaddr),
+            #ipaddress.IPv4Address(0),
+            client_ip,
+            # siaddr - servr address
             ipaddress.IPv4Address(0),
+            # giaddr - gateway address = relay address
             relay_ip,
             mac_addr,
             sname,

--- a/dhcppython/utils.py
+++ b/dhcppython/utils.py
@@ -48,6 +48,28 @@ def random_mac(num_bytes: int = 6, delimiter: str = ":") -> str:
         ["".join(random.choices(VALID_HEX, k=2)) for i in range(num_bytes)]
     )
 
+def random_mac_prefix(num_bytes: int = 6, delimiter: str = ":", prefix: str = "") -> str:
+    """
+    Generates an 6 byte long MAC address with predefined prefix
+
+    >>> random_mac_prefix(prefix="00:0A:A0")
+    '00:0A:A0:85:A4:EF'
+    """
+
+    if not prefix:
+        return random_mac(num_bytes=num_bytes, delimiter=delimiter)
+    else:
+        prefix = prefix.upper()
+        prefix = prefix.replace(":","").replace("-","").replace(".","")
+        if not set(prefix).issubset(set(VALID_HEX)):
+            raise TypeError(f"Wrong characters in MAC prefix: {prefix}")
+        if len(prefix)%2 != 0:
+            raise ValueError(f"Even number of HEX characters expected: {prefix}")
+        prefix_list = [ prefix[i]+prefix[i+1] for i in range(0, len(prefix), 2)]
+        
+        return delimiter.join(prefix_list+
+            ["".join(random.choices(VALID_HEX, k=2)) for i in range(num_bytes-len(prefix)//2)]
+        )
 
 def is_mac_addr(mac_addr: str) -> bool:
     """

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ URL = 'https://github.com/vfrazao-ns1/dhcppython'
 EMAIL = ''
 AUTHOR = 'Victor Frazao'
 REQUIRES_PYTHON = '>=3.8.0'
-VERSION = '0.1.4a'
+VERSION = '0.1.4b'
 
 # What packages are required for this module to be executed?
 REQUIRED = []

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ URL = 'https://github.com/vfrazao-ns1/dhcppython'
 EMAIL = ''
 AUTHOR = 'Victor Frazao'
 REQUIRES_PYTHON = '>=3.8.0'
-VERSION = '0.1.4'
+VERSION = '0.1.4a'
 
 # What packages are required for this module to be executed?
 REQUIRED = []


### PR DESCRIPTION
For our DHCP testing tool using DHCPClient class I have added sending DHCPRELEASE and DHCPINFORM. I also changed handling of Option82 suboptions Circuit_ID and Remote_ID which we are used regularly in our network.